### PR TITLE
feat: Allow selecting sender, receiver, or both via run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,23 +107,55 @@ A `run.sh` script is provided to conveniently set up the environment and start t
 
 ```bash
 chmod +x scripts/run.sh
-./scripts/run.sh
+./scripts/run.sh [mode] [options]
 ```
 
 The script will automatically:
 1. Check Python environment.
 2. Check and create Python virtual environment (`venv`):
    - If the virtual environment doesn't exist, creates a new one and installs all dependencies.
-   - If the virtual environment exists, won't update dependencies by default (unless `--update-deps` flag is used).
+   - If the virtual environment exists, won't update dependencies by default (unless an option like `--update-deps` is used).
 3. Check configuration file:
    - If `config/config.yaml` doesn't exist, prompts to copy from `config.yaml.example` and customize.
-4. Start the main program `main.py`.
+4. Start the main program `main.py`, passing the specified mode.
 
-**Parameters:**
-- `--update-deps`: Force update dependencies in existing virtual environment
-  ```bash
-  ./scripts/run.sh --update-deps
-  ```
+**Arguments & Options:**
+
+-   **`[mode]`** (optional): Specifies which components to run. This argument is passed to `main.py` as `--mode <value>` and will **override** the `sender.enabled` and `receiver.enabled` settings in your `config.yaml`. Can be one of:
+    -   `sender`: Starts only the clipboard sender.
+    -   `receiver`: Starts only the clipboard receiver.
+    -   `both`: Starts both the sender and receiver.
+    If omitted, the script defaults to passing `--mode both` to `main.py`, meaning both components will be enabled unless explicitly disabled by their individual settings in `config.yaml` (however, the command-line override takes precedence if used).
+
+-   **`[options]`**:
+    -   `--update-deps`: Updates Python dependencies before running. This can be combined with the `[mode]` argument.
+
+**Examples:**
+
+-   Run only the sender:
+    ```bash
+    ./scripts/run.sh sender
+    ```
+-   Run only the receiver:
+    ```bash
+    ./scripts/run.sh receiver
+    ```
+-   Run both sender and receiver (this is the default behavior if no mode is specified):
+    ```bash
+    ./scripts/run.sh
+    ```
+    or explicitly:
+    ```bash
+    ./scripts/run.sh both
+    ```
+-   Run only the sender and force update dependencies:
+    ```bash
+    ./scripts/run.sh sender --update-deps
+    ```
+    or (note: for `run.sh` the order of these two specific arguments matters if mode is specified)
+    ```bash
+    ./scripts/run.sh --update-deps sender
+    ```
 
 Press `Ctrl+C` to stop running.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -106,23 +106,55 @@
 
 ```bash
 chmod +x scripts/run.sh
-./scripts/run.sh
+./scripts/run.sh [模式] [选项]
 ```
 
 脚本会自动：
 1. 检查 Python 环境。
 2. 检查并创建 Python 虚拟环境 (`venv`)：
    - 如果虚拟环境不存在，会创建新的虚拟环境并安装所有依赖。
-   - 如果虚拟环境已存在，默认不会更新依赖（除非使用 `--update-deps` 参数）。
+   - 如果虚拟环境已存在，默认不会更新依赖（除非使用像 `--update-deps` 这样的选项）。
 3. 检查配置文件：
    - 如果 `config/config.yaml` 不存在，会提示从 `config.yaml.example` 复制并自定义。
-4. 启动主程序 `main.py`。
+4. 启动主程序 `main.py`，并传递指定的模式。
 
-**参数说明:**
-- `--update-deps`: 强制更新已存在虚拟环境中的依赖包
-  ```bash
-  ./scripts/run.sh --update-deps
-  ```
+**参数与选项:**
+
+-   **`[模式]`** (可选): 指定运行哪些组件。此参数会作为 `--mode <值>` 传递给 `main.py`，并且将 **覆盖** 您 `config.yaml` 文件中的 `sender.enabled` 和 `receiver.enabled` 设置。可以是以下之一：
+    -   `sender`: 仅启动剪贴板发送端。
+    -   `receiver`: 仅启动剪贴板接收端。
+    -   `both`: 同时启动发送端和接收端。
+    如果省略此参数，脚本默认将 `--mode both` 传递给 `main.py`，这意味着两个组件都将被启用，除非在 `config.yaml` 中被各自的设置明确禁用（但如果使用命令行覆盖，则命令行具有优先权）。
+
+-   **`[选项]`**:
+    -   `--update-deps`: 在运行前更新 Python 依赖。此选项可以与 `[模式]` 参数结合使用。
+
+**示例:**
+
+-   仅运行发送端:
+    ```bash
+    ./scripts/run.sh sender
+    ```
+-   仅运行接收端:
+    ```bash
+    ./scripts/run.sh receiver
+    ```
+-   同时运行发送端和接收端 (如果未指定模式，则为默认行为):
+    ```bash
+    ./scripts/run.sh
+    ```
+    或明确指定:
+    ```bash
+    ./scripts/run.sh both
+    ```
+-   仅运行发送端并强制更新依赖:
+    ```bash
+    ./scripts/run.sh sender --update-deps
+    ```
+    或者 (注意: 对于 `run.sh`，如果指定了模式，这两个特定参数的顺序很重要)
+    ```bash
+    ./scripts/run.sh --update-deps sender
+    ```
 
 按 `Ctrl+C` 停止运行。
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -19,12 +19,23 @@ CONFIG_EXAMPLE="config/config.yaml.example"
 # --- Argument Parsing ---
 # Default: do not update dependencies unless requested or first run
 update_dependencies=false
-# Check if the first argument is --update-deps
+SERVICE_MODE="both" # Default service mode
+
+# Check for --update-deps first
 if [[ "$1" == "--update-deps" ]]; then
   update_dependencies=true
   echo "Argument '--update-deps' provided. Will update dependencies."
-  # Shift the arguments so --update-deps isn't passed to the python script
-  shift
+  shift # Remove --update-deps from arguments
+fi
+
+# Check for service mode (sender, receiver, both)
+if [[ "$1" == "sender" || "$1" == "receiver" || "$1" == "both" ]]; then
+  SERVICE_MODE="$1"
+  echo "Service mode specified: $SERVICE_MODE"
+  shift # Remove service mode argument
+else
+  echo "No specific service mode (sender/receiver/both) specified, or argument is not recognized as such. Defaulting to '$SERVICE_MODE'."
+  # Any remaining $1 would be passed to main.py via "$@"
 fi
 
 # --- Functions ---
@@ -143,7 +154,7 @@ echo "Starting the application ($MAIN_SCRIPT)..."
 
 # Use exec to replace the shell process with the Python process
 # Pass remaining arguments (after potentially removing --update-deps) to the Python script
-exec $PYTHON_EXEC "$PROJECT_ROOT/$MAIN_SCRIPT" "$@"
+exec $PYTHON_EXEC "$PROJECT_ROOT/$MAIN_SCRIPT" --mode "$SERVICE_MODE" "$@"
 
 # If exec fails (e.g., python not found after venv activation issues), this line will be reached.
 echo "Error: Failed to execute '$PYTHON_EXEC $PROJECT_ROOT/$MAIN_SCRIPT'" >&2


### PR DESCRIPTION
This commit introduces functionality to specify which components (sender, receiver, or both) to start when using the `scripts/run.sh` script.

Modifications:

- `scripts/run.sh`:
    - Now accepts an optional first argument: `sender`, `receiver`, or `both`.
    - If no mode argument is provided, it defaults to `both`.
    - This mode is passed to `main.py` via a new `--mode <selected_mode>` argument.
    - The `--update-deps` flag can still be used in conjunction with the mode argument.

- `main.py`:
    - Parses the `--mode` argument passed from `run.sh`.
    - The `--mode` argument overrides the `enabled` settings for `sender` and `receiver` found in `config.yaml`.
        - `sender`: Enables sender, disables receiver.
        - `receiver`: Enables receiver, disables sender. - `both`: Enables both sender and receiver.
    - Logs the active mode (whether from command-line override or config).

- `README.md` and `README_zh.md`:
    - Updated to document the new command-line options for `scripts/run.sh`, including examples.

This change provides you with more flexibility in controlling the application's components at startup.